### PR TITLE
WrenSec Builds - Phase #1

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,0 +1,3 @@
+export MAVEN_PACKAGE="openicf-java-framework"
+export BINTRAY_PACKAGE="wrenicf-java-framework"
+export JFROG_PACKAGE="org/forgerock/openicf/framework"

--- a/bundles-parent/pom.xml
+++ b/bundles-parent/pom.xml
@@ -3,6 +3,7 @@
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright (c) 2010-2015 ForgeRock AS. All rights reserved.
+ Portions Copyright 2017 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -24,30 +25,23 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.forgerock.openicf.framework</groupId>
         <artifactId>framework</artifactId>
         <version>1.5.2.0</version>
     </parent>
+
     <groupId>org.forgerock.openicf.connectors</groupId>
     <artifactId>connectors-parent</artifactId>
     <packaging>pom</packaging>
-    <name>OpenICF Connectors</name>
+
+    <name>Wren:ICF - Connector Bundles - Parent</name>
     <description>
-        This pom module is the parent for all connector bundles. It defines the dependencies on framework, building the
-        connector bundle and common reporting for connectors.
-        This is not multi module project, it does not aggregate the connectors, it is just common parent.
+        This is the parent POM for all connector bundles. It specifies the common framework
+        dependencies, and defines the standard process that is used to build connector bundles.
     </description>
-    <distributionManagement>
-        <site>
-            <id>forgerock.org</id>
-            <url>${siteDistributionURL}/connectors/</url>
-        </site>
-    </distributionManagement>
-    <!-- mvn help:effective-pom
-         mvn archetype:create-from-project
-         mvn help:active-profiles
-     -->
+
     <properties>
         <!--
             These are the properties needed in manifest file of the bundle,
@@ -72,6 +66,7 @@
         <openicf.osgi.import.framework.version>
             version="[$(version;==;${project.framework.version}),$(version;+;${project.framework.version}))"
         </openicf.osgi.import.framework.version>
+
         <openicf.osgi.import.strict.version>
             version="[$(version;===;${project.framework.version}),$(version;=+;${project.framework.version}))"
         </openicf.osgi.import.strict.version>
@@ -87,6 +82,7 @@
             ${openicf.osgi.import.additional},
             *
         </openicf.osgi.import.pkg>
+
         <openicf.osgi.import>${openicf.osgi.import.pkg}</openicf.osgi.import>
 
         <openicf.osgi.private />
@@ -107,22 +103,20 @@
         <openicf.osgi.activator />
         <openicf.osgi.dynamic.import />
         <openicf.osgi.include.resource>{maven-resources}</openicf.osgi.include.resource>
+
         <openicf.osgi.import.default.version>
             [$(version;==;$(@)),$(version;=+;$(@)))
         </openicf.osgi.import.default.version>
+
         <openicf.osgi.remove.headers>
             Ignore-Package,Include-Resource,Private-Package,Bundle-DocURL,Embedded-Artifacts,Embed-Dependency,Built-By,
             Build-Jdk,Tool
         </openicf.osgi.remove.headers>
+
         <openicf.osgi.failok>false</openicf.osgi.failok>
         <openicf.osgi.export.service />
         <openicf.osgi.import.service />
         <openicf.osgi.embed />
-        <!-- If we release this project, we need to include the ForgeRock binary license -->
-        <include.binary.license>
-            ${project.build.directory}/maven-shared-archive-resources/legal-notices
-        </include.binary.license>
-
     </properties>
 
     <dependencyManagement>
@@ -140,12 +134,14 @@
                 <version>${project.framework.version}</version>
                 <scope>test</scope>
             </dependency>
+
             <dependency>
                 <groupId>org.forgerock.openicf.framework</groupId>
                 <artifactId>connector-test-common</artifactId>
                 <version>${project.framework.version}</version>
                 <scope>test</scope>
             </dependency>
+
             <dependency>
                 <groupId>org.forgerock.openicf.framework</groupId>
                 <artifactId>connector-framework</artifactId>
@@ -161,13 +157,16 @@
             <testResource>
                 <directory>${project.basedir}/src/test/config</directory>
             </testResource>
+
             <testResource>
                 <directory>${privateConfigPath}</directory>
+
                 <excludes>
                     <exclude>lib/**</exclude>
                     <exclude>**/target/**</exclude>
                 </excludes>
             </testResource>
+
             <!--testResource>
                         <directory>src/test/java</directory>
                         <excludes>
@@ -184,6 +183,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
+
                     <configuration>
                         <links>
                             <link>http://download.oracle.com/javase/8/docs/api/</link>
@@ -192,14 +192,17 @@
                         </links>
                     </configuration>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
+
                     <configuration>
                         <stagingSiteURL>
                             ${siteDistributionURL}/connectors/${project.artifactId}-${project.version}
                         </stagingSiteURL>
                     </configuration>
+
                     <dependencies>
                         <dependency>
                             <groupId>org.forgerock.maven.plugins</groupId>
@@ -208,35 +211,37 @@
                         </dependency>
                     </dependencies>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-scm-plugin</artifactId>
+
                     <configuration>
                         <tag>${project.version}</tag>
-                        <message>[ForgeRock Connector Release] ${project.name}</message>
+                        <message>[Wren Security Connector Release] ${project.name}</message>
                     </configuration>
                 </plugin>
-
 
                 <!--<plugins>-->
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
                     <extensions>true</extensions>
+
                     <configuration>
                         <excludeDependencies>${openicf.osgi.exclude.dependencies}</excludeDependencies>
+
                         <instructions>
                             <!-- Required immutable instructions -->
                             <Embed-Directory>lib</Embed-Directory>
                             <Embed-Transitive>true</Embed-Transitive>
 
-                            <!-- OpenICF Headers -->
+                            <!-- Wren:ICF Headers -->
                             <ConnectorBundle-FrameworkVersion>
                                 ${ConnectorBundle-FrameworkVersion}
                             </ConnectorBundle-FrameworkVersion>
                             <ConnectorBundle-Name>${ConnectorBundle-Name}</ConnectorBundle-Name>
                             <ConnectorBundle-Version>${ConnectorBundle-Version}</ConnectorBundle-Version>
-
 
                             <!-- OSGi Headers -->
                             <Bundle-Name>${project.name}</Bundle-Name>
@@ -254,7 +259,6 @@
                             <Import-Service>${openicf.osgi.import.service}</Import-Service>
                             <Embed-Dependency>${openicf.osgi.embed}</Embed-Dependency>
 
-
                             <!-- Implementation Entries -->
                             <Implementation-Title>${project.name}</Implementation-Title>
                             <Implementation-Version>${project.version}</Implementation-Version>
@@ -268,11 +272,13 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-remote-resources-plugin</artifactId>
+
                     <executions>
                         <execution>
                             <goals>
                                 <goal>process</goal>
                             </goals>
+
                             <configuration>
                                 <resourceBundles>
                                     <resourceBundle>${licenseResourceBundle}</resourceBundle>
@@ -281,38 +287,45 @@
                         </execution>
                     </executions>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <executions>
 
+                    <executions>
                         <!-- Attach also test-jar -->
                         <execution>
                             <id>package-test</id>
+                            <phase>package</phase>
+
+                            <goals>
+                                <goal>test-jar</goal>
+                            </goals>
+
                             <configuration>
                                 <excludes>
                                     <exclude>${connectorName}/**</exclude>
                                 </excludes>
                             </configuration>
-                            <phase>package</phase>
-                            <goals>
-                                <goal>test-jar</goal>
-                            </goals>
                         </execution>
 
                         <!-- Attach public test config -->
                         <execution>
                             <id>package-publictestconfig</id>
                             <phase>package</phase>
+
                             <goals>
                                 <goal>jar</goal>
                             </goals>
+
                             <configuration>
                                 <classesDirectory>${project.build.testOutputDirectory}</classesDirectory>
                                 <classifier>publictestconfig</classifier>
+
                                 <includes>
                                     <include>${connectorName}/**</include>
                                 </includes>
+
                                 <excludes>
                                     <exclude>**/config-private/**</exclude>
                                 </excludes>
@@ -324,6 +337,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
+
                     <configuration>
                         <systemPropertyVariables>
                             <bundleJar>${project.build.directory}/${project.build.finalName}.jar</bundleJar>
@@ -334,6 +348,7 @@
                         </systemPropertyVariables>
                     </configuration>
                 </plugin>
+
                 <plugin>
                     <groupId>org.forgerock.maven.plugins</groupId>
                     <artifactId>openicf-maven-plugin</artifactId>
@@ -342,6 +357,7 @@
             </plugins>
         </pluginManagement>
     </build>
+
     <reporting>
         <plugins>
             <plugin>
@@ -349,9 +365,11 @@
                 <artifactId>openicf-maven-plugin</artifactId>
                 <version>${openicf.maven.plugin.version}</version>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+
                 <configuration>
                     <links>
                         <link>http://download.oracle.com/javase/8/docs/api/</link>
@@ -364,15 +382,16 @@
     </reporting>
 
     <!-- Profiles-->
-
     <profiles>
         <profile>
             <id>generate-docbook</id>
+
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.forgerock.maven.plugins</groupId>
                         <artifactId>openicf-maven-plugin</artifactId>
+
                         <executions>
                             <execution>
                                 <goals>
@@ -381,43 +400,53 @@
                             </execution>
                         </executions>
                     </plugin>
+
                     <plugin>
                         <groupId>org.forgerock.commons</groupId>
                         <artifactId>forgerock-doc-maven-plugin</artifactId>
                         <inherited>true</inherited>
+
                         <configuration>
-                            <projectName>OpenICF</projectName>
+                            <projectName>Wren:ICF</projectName>
                             <googleAnalyticsId>${googleAnalyticsAccountId}</googleAnalyticsId>
                             <projectVersion>${docTargetVersion}</projectVersion>
                             <releaseVersion>${docTargetVersion}</releaseVersion>
                             <docbkxSourceDirectory>${project.build.directory}/openicf-docbkx</docbkxSourceDirectory>
                             <projectVersion>${docTargetVersion}</projectVersion>
                         </configuration>
+
                         <executions>
                             <execution>
                                 <id>pre-process-doc</id>
                                 <phase>pre-site</phase>
+
                                 <goals>
                                     <goal>process</goal>
                                 </goals>
                             </execution>
+
                             <execution>
                                 <id>build-doc</id>
                                 <phase>pre-site</phase>
+
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
                             </execution>
+
                             <execution>
                                 <id>layout-site</id>
                                 <phase>site</phase>
+
                                 <goals>
                                     <goal>site</goal>
                                 </goals>
                             </execution>
+
                             <execution>
                                 <id>layout-release</id>
                                 <phase>site</phase>
+
                                 <goals>
                                     <goal>release</goal>
                                 </goals>

--- a/connector-framework-internal/pom.xml
+++ b/connector-framework-internal/pom.xml
@@ -3,6 +3,7 @@
  DO NOT REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright (c) 2010-2015 ForgeRock AS. All rights reserved.
+ Portions Copyright 2017 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -24,17 +25,20 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.forgerock.openicf.framework</groupId>
         <artifactId>framework</artifactId>
         <version>1.5.2.0</version>
     </parent>
+
     <artifactId>connector-framework-internal</artifactId>
     <packaging>bundle</packaging>
-    <name>OpenICF Framework - Internal</name>
+
+    <name>Wren:ICF - Framework - Internal</name>
     <description>
-        The IdentityConnectors framework provides a container to separate the Connector bundle from the application.
-        The framework provides many common features that developers would otherwise need to implement on their own.
+        This package provides logic that is used internally by shared code in the Identity Connector
+        framework.
     </description>
 
     <dependencies>
@@ -51,6 +55,7 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.openicf.framework</groupId>
             <artifactId>connector-test-common</artifactId>
@@ -65,10 +70,12 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.easytesting</groupId>
             <artifactId>fest-assert</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.openicf.framework</groupId>
             <artifactId>connector-framework</artifactId>
@@ -76,12 +83,14 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>io.reactivex</groupId>
             <artifactId>rxjava</artifactId>
             <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
+
         <!-- Force to build the test bundles before -->
         <dependency>
             <groupId>org.forgerock.openicf.framework</groupId>
@@ -89,6 +98,7 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.openicf.framework</groupId>
             <artifactId>testbundlev2</artifactId>
@@ -96,18 +106,14 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <properties>
-        <!-- If we release this project, we need to include the Forgerock binary license -->
-        <include.binary.license>
-            ${project.build.directory}/maven-shared-archive-resources/legal-notices
-        </include.binary.license>
-    </properties>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+
                 <configuration>
                     <instructions>
                         <Import-Package>
@@ -116,35 +122,43 @@
                             groovy*;version="[1.8,3)",
                             *
                         </Import-Package>
+
                         <Export-Package>
                             org.identityconnectors.framework.impl.api*
                         </Export-Package>
+
                         <Main-Class>org.identityconnectors.framework.server.Main</Main-Class>
                         <Fragment-Host>org.forgerock.openicf.framework.connector-framework</Fragment-Host>
                     </instructions>
                 </configuration>
             </plugin>
+
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
+
                 <executions>
                     <!-- Copy bundle JARs -->
                     <execution>
                         <id>copy-contractclasses</id>
                         <phase>process-test-classes</phase>
+
                         <goals>
                             <goal>copy</goal>
                         </goals>
+
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>org.forgerock.openicf.framework</groupId>
                                     <artifactId>testbundlev1</artifactId>
                                 </artifactItem>
+
                                 <artifactItem>
                                     <groupId>org.forgerock.openicf.framework</groupId>
                                     <artifactId>testbundlev2</artifactId>
                                 </artifactItem>
                             </artifactItems>
+
                             <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
                             <stripVersion>true</stripVersion>
                         </configuration>

--- a/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/ObjectPool.java
+++ b/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/ObjectPool.java
@@ -20,6 +20,7 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
  * Portions Copyrighted 2010-2015 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
 
 package org.identityconnectors.framework.impl.api.local;
@@ -346,8 +347,8 @@ public class ObjectPool<T> {
 
     /**
      * Closes any idle objects in the pool.
-     * <p/>
-     * Existing active objects will remain alive and be allowed to shutdown
+     *
+     * <p>Existing active objects will remain alive and be allowed to shutdown
      * gracefully, but no more objects will be allocated.
      */
     public void shutdown() {

--- a/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/ObjectPoolHandler.java
+++ b/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/ObjectPoolHandler.java
@@ -20,6 +20,7 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
  * Portions Copyrighted 2010-2013 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
 
 package org.identityconnectors.framework.impl.api.local;
@@ -31,9 +32,9 @@ public interface ObjectPoolHandler<T> {
     /**
      * Validates, copies and updates the original
      * {@code ObjectPoolConfiguration}.
-     * <p/>
-     * This class can validate and if necessary it changes the {@code original}
-     * configuration.
+     *
+     * <p>This class can validate and if necessary it changes the
+     * {@code original} configuration.
      *
      * @param original
      *            custom configured instance.
@@ -43,8 +44,8 @@ public interface ObjectPoolHandler<T> {
 
     /**
      * Makes a new instance of the pooled object.
-     * <p/>
-     * This method is called whenever a new instance is needed.
+     *
+     * <p>This method is called whenever a new instance is needed.
      *
      * @return new instance of T.
      */
@@ -52,8 +53,8 @@ public interface ObjectPoolHandler<T> {
 
     /**
      * Tests the borrowed object.
-     * <p/>
-     * This method is invoked on head instances to make sure they can be
+     *
+     * <p>This method is invoked on head instances to make sure they can be
      * borrowed from the pool.
      *
      * @param object
@@ -63,8 +64,8 @@ public interface ObjectPoolHandler<T> {
 
     /**
      * Disposes the object.
-     * <p/>
-     * This method is invoked on every instance when it is being "dropped" from
+     *
+     * <p>This method is invoked on every instance when it is being "dropped" from
      * the pool (whether due to the response from {@link #testObject(Object)},
      * or for reasons specific to the pool implementation.)
      *
@@ -75,8 +76,8 @@ public interface ObjectPoolHandler<T> {
 
     /**
      * Releases any allocated resources.
-     * <p/>
-     * Existing active objects will remain alive and be allowed to shutdown
+     *
+     * <p>Existing active objects will remain alive and be allowed to shutdown
      * gracefully, but no more objects will be allocated.
      */
     public void shutdown();

--- a/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/AuthenticationImpl.java
+++ b/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/AuthenticationImpl.java
@@ -3,6 +3,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms of the Common Development
  * and Distribution License("CDDL") (the "License").  You may not use this file
@@ -44,8 +45,6 @@ public class AuthenticationImpl extends ConnectorAPIOperationRunner implements
 
     /**
      * Authenticate using the basic credentials.
-     *
-     * @see AuthenticationOpTests#authenticate(String, String)
      */
     public Uid authenticate(final ObjectClass objectClass, final String username,
             final GuardedString password,

--- a/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/BatchImpl.java
+++ b/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/BatchImpl.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -69,9 +70,6 @@ public class BatchImpl extends ConnectorAPIOperationRunner implements
         this.referenceCounter = referenceCounter;
     }
 
-    /**
-     * {@inherit}
-     */
     public Subscription executeBatch(final List<BatchTask> tasks, final Observer<BatchResult> observer,
                                final OperationOptions options) {
         if (tasks == null || tasks.size() == 0) {
@@ -109,9 +107,6 @@ public class BatchImpl extends ConnectorAPIOperationRunner implements
 
     }
 
-    /**
-     * {@inherit}
-     */
     public Subscription queryBatch(final BatchToken batchToken, final Observer<BatchResult> observer,
                              final OperationOptions options) {
         Assertions.nullCheck(batchToken, "batchToken");

--- a/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/remote/RemoteWrappedException.java
+++ b/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/remote/RemoteWrappedException.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2013 ForgeRock AS. All Rights Reserved
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -36,14 +37,11 @@ import org.identityconnectors.framework.common.exceptions.ConnectorException;
 /**
  * RemoteWrappedException wraps every exception which are received from Remote
  * Connector Server.
- * <p/>
- * <b>This Exception is not allowed to use in Connectors!!!</b>
- * <p/>
  *
+ * <p><b>This Exception is not allowed for use by Connectors</b>
  *
- *
- * This type of exception is not allowed to be serialise because this exception
- * represents any after deserialization.
+ * <p>This type of exception is not allowed to be serialise because this
+ * exception represents any after deserialization.
  *
  * This code example show how to get the remote stack trace and how to use the
  * same catches to handle the exceptions regardless its origin.
@@ -64,7 +62,7 @@ import org.identityconnectors.framework.common.exceptions.ConnectorException;
  *          t.printStackTrace();
  *      }
  *  }
- * <code>
+ * </code>
  * </pre>
  *
  * @author Laszlo Hordos

--- a/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/serializer/ObjectDecoder.java
+++ b/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/serializer/ObjectDecoder.java
@@ -3,6 +3,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms of the Common Development
  * and Distribution License("CDDL") (the "License").  You may not use this file
@@ -29,12 +30,16 @@ package org.identityconnectors.framework.impl.serializer;
  */
 public interface ObjectDecoder {
     /**
-     * Reads an object using the appropriate serializer for that object
-     * @param fieldName A hint of the field name. Ignored for binary
-     * serialization. The subelement name for xml serialization
-     * @expectedType Ignored for binary serialization. For xml serialization,
-     * this must be specified if it was written in-line.
-     * @dflt The default value if there is no value.
+     * Reads an object using the appropriate serializer for that object.
+     *
+     * @param fieldName
+     *   A hint of the field name. Ignored for binary serialization. The
+     *   subelement name for xml serialization
+     * @param expectedType
+     *   Ignored for binary serialization. For xml serialization, this must be
+     *   specified if it was written in-line.
+     * @param dflt
+     *   The default value if there is no value.
      */
     public Object readObjectField(String fieldName,
             Class<?> expectedType,
@@ -42,57 +47,78 @@ public interface ObjectDecoder {
 
     /**
      * Reads a boolean.
-     * @param fieldName A hint of the field name. Ignored for binary
-     * serialization. The attribute name for xml serialization
-     * @dflt The default value if there is no value.
+     *
+     * @param fieldName
+     *   A hint of the field name. Ignored for binary serialization. The
+     *   attribute name for xml serialization
+     * @param dflt
+     *   The default value if there is no value.
      */
     public boolean readBooleanField(String fieldName, boolean dflt);
 
     /**
      * Reads an int.
-     * @param fieldName A hint of the field name. Ignored for binary
-     * serialization. The attribute name for xml serialization
-     * @dflt The default value if there is no value.
+     *
+     * @param fieldName
+     *   A hint of the field name. Ignored for binary serialization. The
+     *   attribute name for xml serialization
+     * @param dflt
+     *   The default value if there is no value.
      */
     public int readIntField(String fieldName, int dflt);
 
     /**
      * Reads a long.
-     * @param fieldName A hint of the field name. Ignored for binary
-     * serialization. The attribute name for xml serialization
-     * @dflt The default value if there is no value.
+     *
+     * @param fieldName
+     *   A hint of the field name. Ignored for binary serialization. The
+     *   attribute name for xml serialization
+     * @param dflt
+     *   The default value if there is no value.
      */
     public long readLongField(String fieldName, long dflt);
 
     /**
      * Reads a float.
-     * @param fieldName A hint of the field name. Ignored for binary
-     * serialization. The attribute name for xml serialization
-     * @dflt The default value if there is no value.
+     *
+     * @param fieldName
+     *   A hint of the field name. Ignored for binary serialization. The
+     *   attribute name for xml serialization
+     * @param dflt
+     *   The default value if there is no value.
      */
     public float readFloatField(String fieldName, float dflt );
 
     /**
      * Reads a Class.
-     * @param fieldName A hint of the field name. Ignored for binary
-     * serialization. The attribute name for xml serialization
-     * @dflt The default value if there is no value.
+     *
+     * @param fieldName
+     *   A hint of the field name. Ignored for binary serialization. The
+     *   attribute name for xml serialization
+     * @param dflt
+     *   The default value if there is no value.
      */
     public Class<?> readClassField(String fieldName, Class<?> dflt );
 
     /**
      * Reads a String.
-     * @param fieldName A hint of the field name. Ignored for binary
-     * serialization. The attribute name for xml serialization
-     * @dflt The default value if there is no value.
+     *
+     * @param fieldName
+     *   A hint of the field name. Ignored for binary serialization. The
+     *   attribute name for xml serialization
+     * @param dflt
+     *   The default value if there is no value.
      */
     public String readStringField(String fieldName, String dflt );
 
     /**
      * Reads a double.
-     * @param fieldName A hint of the field name. Ignored for binary
-     * serialization. The attribute name for xml serialization
-     * @dflt The default value if there is no value.
+     *
+     * @param fieldName
+     *   A hint of the field name. Ignored for binary serialization. The
+     *   attribute name for xml serialization
+     * @param dflt
+     *   The default value if there is no value.
      */
     public double readDoubleField(String fieldName, double dflt );
 
@@ -143,7 +169,6 @@ public interface ObjectDecoder {
 
     /**
      * Returns the number of anonymous sub-objects.
-     * @return
      */
     public int getNumSubObjects();
 

--- a/connector-framework-internal/src/main/java/org/identityconnectors/framework/server/ConnectorServer.java
+++ b/connector-framework-internal/src/main/java/org/identityconnectors/framework/server/ConnectorServer.java
@@ -3,6 +3,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms of the Common Development
  * and Distribution License("CDDL") (the "License").  You may not use this file
@@ -355,8 +356,6 @@ public abstract class ConnectorServer {
 
     /**
      * Gets the time when the servers was started last time.
-     * <p/>
-     * {@code System.currentTimeMillis()}
      *
      * @return last start dateTime in milliseconds
      */

--- a/connector-framework-osgi/pom.xml
+++ b/connector-framework-osgi/pom.xml
@@ -3,6 +3,7 @@
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright (c) 2010-2015 ForgeRock AS. All rights reserved.
+ Portions Copyright 2017 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -24,17 +25,20 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.forgerock.openicf.framework</groupId>
         <artifactId>framework</artifactId>
         <version>1.5.2.0</version>
     </parent>
+
     <artifactId>connector-framework-osgi</artifactId>
     <packaging>bundle</packaging>
-    <name>OpenICF Framework - OSGi</name>
+
+    <name>Wren:ICF - Framework - OSGi</name>
     <description>
-        The IdentityConnectors framework provides a container to separate the Connector bundle from the application.
-        The framework provides many common features that developers would otherwise need to implement on their own.
+        This package provides the appropriate wrapper interfaces and logic to run a connector inside
+        an OSGi container without the connector bundle having to interface with OSGi directly.
     </description>
 
     <dependencies>
@@ -43,11 +47,13 @@
             <artifactId>connector-framework</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.openicf.framework</groupId>
             <artifactId>connector-framework-internal</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.ops4j.pax.swissbox</groupId>
             <artifactId>pax-swissbox-extender</artifactId>
@@ -61,6 +67,7 @@
             <version>4.3.1</version>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -68,18 +75,14 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-    <properties>
-        <!-- If we release this project, we need to include the Forgerock binary license -->
-        <include.binary.license>
-            ${project.build.directory}/maven-shared-archive-resources/legal-notices
-        </include.binary.license>
-    </properties>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+
                 <configuration>
                     <instructions>
                         <Bundle-Activator>org.forgerock.openicf.framework.impl.api.osgi.internal.Activator</Bundle-Activator>

--- a/connector-framework-osgi/src/main/java/org/forgerock/openicf/framework/impl/api/osgi/internal/OsgiConnectorInfoManagerImpl.java
+++ b/connector-framework-osgi/src/main/java/org/forgerock/openicf/framework/impl/api/osgi/internal/OsgiConnectorInfoManagerImpl.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2010-2013 ForgeRock AS. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -75,7 +76,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The OSGi ConnectorInfoManager Implementation ...
- * <p/>
  *
  * @author Laszlo Hordos
  * @since 1.1

--- a/connector-framework-protobuf/pom.xml
+++ b/connector-framework-protobuf/pom.xml
@@ -3,6 +3,7 @@
  DO NOT REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright (c) 2015 ForgeRock AS. All rights reserved.
+ Portions Copyright 2017 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -23,18 +24,22 @@
  "Portions Copyrighted [year] [name of copyright owner]"
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>framework</artifactId>
         <groupId>org.forgerock.openicf.framework</groupId>
         <version>1.5.2.0</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>connector-framework-protobuf</artifactId>
     <packaging>bundle</packaging>
-    <name>OpenICF Framework - Protocol Buffer Messages</name>
-    <description>
 
+    <name>Wren:ICF - Framework - Protocol Buffer Messages</name>
+    <description>
+        This module defines the structure of messages Wren:ICF exchanges over the highly efficient
+        Google Protobuf binary format with Connectors written in other languages (including
+        .NET).
     </description>
 
     <properties>
@@ -59,6 +64,7 @@
                 <directory>src/main/protobuf</directory>
             </resource>
         </resources>
+
         <plugins>
             <plugin>
                 <groupId>com.github.os72</groupId>
@@ -67,18 +73,22 @@
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>
+
                         <goals>
                             <goal>run</goal>
                         </goals>
+
                         <configuration>
                             <protocVersion>3.0.0</protocVersion>
                             <addSources>main</addSources>
+
                             <includeDirectories>
                                 <include>src/main/java</include>
                             </includeDirectories>
                         </configuration>
                     </execution>
                 </executions>
+
                 <dependencies>
                     <dependency>
                         <groupId>com.github.os72</groupId>

--- a/connector-framework-protobuf/src/main/java/org/forgerock/openicf/common/protobuf/package-info.java
+++ b/connector-framework-protobuf/src/main/java/org/forgerock/openicf/common/protobuf/package-info.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -23,9 +24,10 @@
  */
 
 /**
- * Provide the Google Protocol Buffer Messages required for the Remote OpenICF Server communication.
- * <p/>
- * The messages are extracted for easy extensibility in the future.  
+ * Provide the Google Protocol Buffer Messages required for the Remote OpenICF
+ * Server communication.
+ *
+ * <p>The messages are extracted for easy extensibility in the future.
  * 
  * @since 1.5
  */

--- a/connector-framework-rpc/pom.xml
+++ b/connector-framework-rpc/pom.xml
@@ -3,6 +3,7 @@
  DO NOT REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright (c) 2015 ForgeRock AS. All rights reserved.
+ Portions Copyright 2017 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -23,18 +24,21 @@
  "Portions Copyrighted [year] [name of copyright owner]"
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>framework</artifactId>
         <groupId>org.forgerock.openicf.framework</groupId>
         <version>1.5.2.0</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>connector-framework-rpc</artifactId>
     <packaging>bundle</packaging>
-    <name>OpenICF Framework - Remote Procedure Call API</name>
-    <description>
 
+    <name>Wren:ICF - Framework - Remote Procedure Call API</name>
+    <description>
+        This module provides common code for interfacing with identity stores that communicate via
+        Remote Procedure Calls.
     </description>
 
     <properties>
@@ -44,9 +48,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-
     <dependencies>
-
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>forgerock-util</artifactId>
@@ -58,12 +60,14 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.easytesting</groupId>
             <artifactId>fest-assert</artifactId>
             <version>1.4</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
@@ -71,12 +75,14 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+
                 <configuration>
                     <instructions>
                     </instructions>

--- a/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/LocalRequest.java
+++ b/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/LocalRequest.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -29,10 +30,9 @@ import org.forgerock.util.promise.ResultHandler;
 
 /**
  * A LocalRequest represents a remotely requested procedure call locally.
- * <p/>
- * The {@link RemoteRequest} and LocalRequest are the representation of the same
- * call on caller and receiver side.
  *
+ * <p>The {@link RemoteRequest} and LocalRequest are the representation of the
+ * same call on caller and receiver side.
  */
 public abstract class LocalRequest<V, E extends Exception, G extends RemoteConnectionGroup<G, H, P>, H extends RemoteConnectionHolder<G, H, P>, P extends RemoteConnectionContext<G, H, P>>
         implements ResultHandler<V>, ExceptionHandler<E> {
@@ -48,10 +48,12 @@ public abstract class LocalRequest<V, E extends Exception, G extends RemoteConne
     }
 
     /**
-     * Check if this object was {@ref inconsistent}-ed and don't dispose.
+     * Check if this object was marked inconsistent and should not be disposed.
      *
      * @return 'true' when object is still active or 'false' when this can be
      *         disposed.
+     *
+     * @see #inconsistent()
      */
     public abstract boolean check();
 

--- a/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/RemoteConnectionContext.java
+++ b/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/RemoteConnectionContext.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -28,8 +29,8 @@ package org.forgerock.openicf.common.rpc;
  * A RemoteConnectionContext is a custom context to provide application specific
  * information to create the
  * {@link org.forgerock.openicf.common.rpc.RemoteRequest}.
- * <p/>
- * The {@link org.forgerock.openicf.common.rpc.RemoteRequest} may depends on
+ *
+ * <p>The {@link org.forgerock.openicf.common.rpc.RemoteRequest} may depends on
  * which {@link org.forgerock.openicf.common.rpc.RemoteConnectionGroup}
  * distributes the request. Instance of this class is provided to
  * {@link org.forgerock.openicf.common.rpc.RemoteRequestFactory} to produce the
@@ -41,12 +42,10 @@ public interface RemoteConnectionContext<G extends RemoteConnectionGroup<G, H, P
 
     /**
      * Return the {@link org.forgerock.openicf.common.rpc.RemoteConnectionGroup}
-     * <p/>
-     * Return the {@link org.forgerock.openicf.common.rpc.RemoteConnectionGroup}
-     * in which this instance belongs to.
+     * to which this instance belongs.
      * 
      * @return the
-     *         {@link org.forgerock.openicf.common.rpc.RemoteConnectionGroup} in
+     *         {@link org.forgerock.openicf.common.rpc.RemoteConnectionGroup} to
      *         which this instance belongs to.
      */
     G getRemoteConnectionGroup();

--- a/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/RemoteConnectionGroup.java
+++ b/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/RemoteConnectionGroup.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -38,12 +39,12 @@ import org.forgerock.util.promise.Promise;
 /**
  * A RemoteConnectionGroups represent a remote pair of another instance of
  * RemoteConnectionGroups.
- * <p/>
- * RemoteConnectionGroups holds the
+ *
+ * <p>RemoteConnectionGroups holds the
  * {@link org.forgerock.openicf.common.rpc.RemoteConnectionHolder} which are
  * connected to the remotely paired RemoteConnectionGroups.
- * <p/>
- * The local instance of {@link RemoteConnectionGroup#remoteRequests} paired
+ *
+ * <p>The local instance of {@link RemoteConnectionGroup#remoteRequests} paired
  * with the remote instance of {@link RemoteConnectionGroup#localRequests}.
  *
  */

--- a/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/RemoteConnectionHolder.java
+++ b/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/RemoteConnectionHolder.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -29,10 +30,10 @@ import java.util.concurrent.Future;
 /**
  * A RemoteConnectionHolder is a wrapper class for the underlying communication
  * chanel.
- * <p/>
- * The API is detached from the real underlying protocol and abstracted through
- * this interface. The message transmitted via this implementation should
- * trigger the appropriate method on
+ *
+ * <p>The API is detached from the real underlying protocol and abstracted
+ * through this interface. The message transmitted via this implementation
+ * should trigger the appropriate method on
  * {@link org.forgerock.openicf.common.rpc.MessageListener}.
  *
  */

--- a/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/RemoteRequest.java
+++ b/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/RemoteRequest.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -36,9 +37,9 @@ import org.forgerock.util.promise.ResultHandler;
 /**
  * A RemoteRequest represents a locally requested procedure call executed
  * remotely.
- * <p/>
- * The RemoteRequest and {@link LocalRequest} are the representation of the same
- * call on caller and receiver side.
+ *
+ * <p>The RemoteRequest and {@link LocalRequest} are the representation of the
+ * same call on caller and receiver side.
  *
  */
 public abstract class RemoteRequest<V, E extends Exception, G extends RemoteConnectionGroup<G, H, P>, H extends RemoteConnectionHolder<G, H, P>, P extends RemoteConnectionContext<G, H, P>> {
@@ -59,10 +60,12 @@ public abstract class RemoteRequest<V, E extends Exception, G extends RemoteConn
     }
 
     /**
-     * Check if this object was {@ref inconsistent}-ed and don't dispose.
+     * Check if this object was marked inconsistent and should not be disposed.
      *
      * @return 'true' when object is still active or 'false' when this can be
      *         disposed.
+     *
+     * @see #inconsistent()
      */
     public abstract boolean check();
 

--- a/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/RequestDistributor.java
+++ b/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/RequestDistributor.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -28,17 +29,17 @@ package org.forgerock.openicf.common.rpc;
  * A RequestDistributor delivers the
  * {@link org.forgerock.openicf.common.rpc.RemoteRequest} to the connected
  * endpoint.
- * <p/>
- * The {@link org.forgerock.openicf.common.rpc.RemoteRequestFactory} is used to
- * create a {@link org.forgerock.openicf.common.rpc.RemoteConnectionContext}
+ *
+ * <p>The {@link org.forgerock.openicf.common.rpc.RemoteRequestFactory} is used
+ * to create a {@link org.forgerock.openicf.common.rpc.RemoteConnectionContext}
  * aware {@link org.forgerock.openicf.common.rpc.RemoteRequest} which will be
  * delivered.
- * <p/>
- * The implementation may hold multiple transmission channels and try all to
+ *
+ * <p>The implementation may hold multiple transmission channels and try all to
  * deliver the message before if fails.
- * <p/>
- * The failed delivery signaled with null empty to avoid the expensive Throw and
- * Catch especially when many implementation are chained together.
+ *
+ * <p>The failed delivery signaled with null empty to avoid the expensive Throw
+ * and Catch especially when many implementation are chained together.
  * 
  * @see org.forgerock.openicf.common.rpc.FailoverLoadBalancingAlgorithm
  * @see org.forgerock.openicf.common.rpc.RoundRobinLoadBalancingAlgorithm

--- a/connector-framework-server/pom.xml
+++ b/connector-framework-server/pom.xml
@@ -3,6 +3,7 @@
  DO NOT REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright (c) 2010-2015 ForgeRock AS. All rights reserved.
+ Portions Copyright 2017 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -32,9 +33,9 @@
 
     <artifactId>connector-framework-server</artifactId>
     <packaging>bundle</packaging>
-    <name>OpenICF Framework - Server</name>
+    <name>Wren:ICF - Framework - Server Core</name>
     <description>
-        
+        Provides Connectors with the ability to run a Connector as a standalone server.
     </description>
 
     <properties>
@@ -50,20 +51,24 @@
             <artifactId>connector-framework-internal</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.openicf.framework</groupId>
             <artifactId>connector-framework-rpc</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.openicf.framework</groupId>
             <artifactId>connector-framework-protobuf</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>forgerock-util</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.commons.guava</groupId>
             <artifactId>forgerock-guava-collect</artifactId>
@@ -75,11 +80,13 @@
             <artifactId>grizzly-framework</artifactId>
             <version>${grizzly.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http-servlet</artifactId>
             <version>${grizzly.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-websockets</artifactId>
@@ -113,8 +120,6 @@
             <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
-        
-
 
         <!-- Test Dependencies -->
         <dependency>
@@ -122,31 +127,34 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.easytesting</groupId>
             <artifactId>fest-assert</artifactId>
             <version>1.4</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>${groovy.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.openicf.framework</groupId>
             <artifactId>testbundlev1</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>io.reactivex</groupId>
             <artifactId>rxjava</artifactId>
             <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>
@@ -157,19 +165,23 @@
             -->
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
+
                 <executions>
                     <execution>
                         <id>build-test-jar</id>
+
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+
                 <configuration>
                     <instructions>
                         <Bundle-Activator>org.forgerock.openicf.framework.osgi.internal.Activator</Bundle-Activator>

--- a/connector-framework-server/src/main/java/org/forgerock/openicf/framework/async/AsyncConnectorInfoManager.java
+++ b/connector-framework-server/src/main/java/org/forgerock/openicf/framework/async/AsyncConnectorInfoManager.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -41,7 +42,7 @@ public interface AsyncConnectorInfoManager extends ConnectorInfoManager {
     /**
      * Add a promise which will be fulfilled with the
      * {@link org.identityconnectors.framework.api.ConnectorInfo} for the given
-     * {@ConnectorKey}.
+     * {@link ConnectorKey}.
      * 
      * Add a Promise which will be fulfilled immediately if the
      * {@link org.identityconnectors.framework.api.ConnectorInfo} is maintained
@@ -55,7 +56,7 @@ public interface AsyncConnectorInfoManager extends ConnectorInfoManager {
     /**
      * Add a promise which will be fulfilled with the
      * {@link org.identityconnectors.framework.api.ConnectorInfo} for the given
-     * {@ConnectorKeyRange}.
+     * {@link ConnectorKeyRange}.
      *
      * Add a Promise which will be fulfilled immediately if the
      * {@link org.identityconnectors.framework.api.ConnectorInfo} is maintained

--- a/connector-framework-server/src/main/java/org/forgerock/openicf/framework/osgi/internal/AsyncOsgiConnectorInfoManagerImpl.java
+++ b/connector-framework-server/src/main/java/org/forgerock/openicf/framework/osgi/internal/AsyncOsgiConnectorInfoManagerImpl.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -65,7 +66,6 @@ import org.osgi.framework.Bundle;
 
 /**
  * The OSGi ConnectorInfoManager Implementation ...
- * <p/>
  *
  * @author Laszlo Hordos
  * @since 1.1

--- a/connector-framework-server/src/main/java/org/forgerock/openicf/framework/remote/SecurityUtil.java
+++ b/connector-framework-server/src/main/java/org/forgerock/openicf/framework/remote/SecurityUtil.java
@@ -12,8 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
-
 package org.forgerock.openicf.framework.remote;
 
 import java.math.BigInteger;
@@ -169,8 +169,8 @@ public class SecurityUtil {
 
     /**
      * Load a class with a given name.
-     * <p/>
-     * It will try to load the class in the following order:
+     *
+     * <p>It will try to load the class in the following order:
      * <ul>
      * <li>From Thread.currentThread().getContextClassLoader()
      * <li>Using the basic Class.forName()

--- a/connector-framework/pom.xml
+++ b/connector-framework/pom.xml
@@ -3,6 +3,7 @@
  DO NOT REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright (c) 2010-2015 ForgeRock AS. All rights reserved.
+ Portions Copyright 2017 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -24,17 +25,21 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.forgerock.openicf.framework</groupId>
         <artifactId>framework</artifactId>
         <version>1.5.2.0</version>
     </parent>
+
     <artifactId>connector-framework</artifactId>
     <packaging>bundle</packaging>
-    <name>OpenICF Framework</name>
+
+    <name>Wren:ICF - Framework</name>
     <description>
-        The IdentityConnectors framework provides a container to separate the Connector bundle from the application.
-        The framework provides many common features that developers would otherwise need to implement on their own.
+        The Identity Connectors framework defines a common interface and shared code that simplifies
+        each Connector bundle and allows it to operate with the same code across several versions of
+        the same identity applications.
     </description>
 
     <dependencies>
@@ -43,17 +48,13 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.easytesting</groupId>
             <artifactId>fest-assert</artifactId>
         </dependency>
     </dependencies>
-    <properties>
-        <!-- If we release this project, we need to include the Forgerock binary license -->
-        <include.binary.license>
-            ${project.build.directory}/maven-shared-archive-resources/legal-notices
-        </include.binary.license>
-    </properties>
+
     <build>
         <plugins>
             <!--
@@ -62,19 +63,23 @@
             -->
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
+
                 <executions>
                     <execution>
                         <id>build-test-jar</id>
+
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+
                 <configuration>
                     <instructions>
                         <DynamicImport-Package>*</DynamicImport-Package>

--- a/connector-framework/src/main/java/org/identityconnectors/common/IOUtil.java
+++ b/connector-framework/src/main/java/org/identityconnectors/common/IOUtil.java
@@ -21,6 +21,7 @@
  * ====================
  * Portions Copyrighted 2013 ConnId
  * Portions Copyrighted 2015 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
 package org.identityconnectors.common;
 
@@ -70,10 +71,10 @@ public final class IOUtil {
 
     /**
      * Quietly closes the reader.
-     * <p/>
-     * This avoids having to handle exceptions, and then inside of the exception
-     * handling have a try catch block to close the reader and catch any
-     * {@link IOException} which may be thrown and ignore it.
+     *
+     * <p>This avoids having to handle exceptions, and then inside of the
+     * exception handling have a try catch block to close the reader and catch
+     * any {@link IOException} which may be thrown and ignore it.
      *
      * @param reader
      *            Reader to close
@@ -90,10 +91,10 @@ public final class IOUtil {
 
     /**
      * Quietly closes the stream.
-     * <p/>
-     * This avoids having to handle exceptions, and then inside of the exception
-     * handling have a try catch block to close the stream and catch any
-     * {@link IOException} which may be thrown.
+     *
+     * <p>This avoids having to handle exceptions, and then inside of the
+     * exception handling have a try catch block to close the stream and catch
+     * any {@link IOException} which may be thrown.
      *
      * @param stream
      *            Stream to close
@@ -110,10 +111,10 @@ public final class IOUtil {
 
     /**
      * Quietly closes the writer.
-     * <p/>
-     * This avoids having to handle exceptions, and then inside of the exception
-     * handling have a try catch block to close the Writer and catch any
-     * {@link IOException} which may be thrown.
+     *
+     * <p>This avoids having to handle exceptions, and then inside of the
+     * exception handling have a try catch block to close the Writer and catch
+     * any {@link IOException} which may be thrown.
      *
      * @param writer
      *            Writer to close
@@ -130,10 +131,10 @@ public final class IOUtil {
 
     /**
      * Quietly closes the stream.
-     * <p/>
-     * This avoids having to handle exceptions, and then inside of the exception
-     * handling have a try catch block to close the stream and catch any
-     * {@link IOException} which may be thrown.
+     *
+     * <p>This avoids having to handle exceptions, and then inside of the
+     * exception handling have a try catch block to close the stream and catch
+     * any {@link IOException} which may be thrown.
      *
      * @param stream
      *            Stream to close
@@ -150,10 +151,10 @@ public final class IOUtil {
 
     /**
      * Quietly closes the statement.
-     * <p/>
-     * This avoids having to handle exceptions, and then inside of the exception
-     * handling have a try catch block to close the statement and catch any
-     * {@link SQLException} which may be thrown.
+     *
+     * <p>This avoids having to handle exceptions, and then inside of the
+     * exception handling have a try catch block to close the statement and
+     * catch any {@link SQLException} which may be thrown.
      *
      * @param stmt
      *            Statement to close
@@ -171,10 +172,10 @@ public final class IOUtil {
 
     /**
      * Quietly closes the connection.
-     * <p/>
-     * This avoids having to handle exceptions, and then inside of the exception
-     * handling have a try catch block to close the connection and catch any
-     * {@link SQLException} which may be thrown.
+     *
+     * <p>This avoids having to handle exceptions, and then inside of the
+     * exception handling have a try catch block to close the connection and
+     * catch any {@link SQLException} which may be thrown.
      *
      * @param conn
      *            Connection to close
@@ -192,10 +193,10 @@ public final class IOUtil {
 
     /**
      * Quietly closes the resultset.
-     * <p/>
-     * This avoids having to handle exceptions, and then inside of the exception
-     * handling have a try catch block to close the connection and catch any
-     * {@link SQLException} which may be thrown.
+     *
+     * <p>This avoids having to handle exceptions, and then inside of the
+     * exception handling have a try catch block to close the connection and
+     * catch any {@link SQLException} which may be thrown.
      *
      * @param resultset
      *            ResultSet to close

--- a/connector-framework/src/main/java/org/identityconnectors/common/VersionRange.java
+++ b/connector-framework/src/main/java/org/identityconnectors/common/VersionRange.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2013-2015 ForgeRock AS. All Rights Reserved
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -26,15 +27,13 @@ package org.identityconnectors.common;
 
 /**
  * A version range is an interval describing a set of {@link Version versions}.
- * <p/>
- * A range has a left (lower) endpoint and a right (upper) endpoint. Each
+ *
+ * <p>A range has a left (lower) endpoint and a right (upper) endpoint. Each
  * endpoint can be open (excluded from the set) or closed (included in the set).
  *
- * <p>
- * {@code VersionRange} objects are immutable.
+ * <p>{@code VersionRange} objects are immutable.
  *
  * @author Laszlo Hordos
- * @Immutable
  * @since 1.4
  */
 public class VersionRange {

--- a/connector-framework/src/main/java/org/identityconnectors/common/XmlUtil.java
+++ b/connector-framework/src/main/java/org/identityconnectors/common/XmlUtil.java
@@ -3,6 +3,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms of the Common Development
  * and Distribution License("CDDL") (the "License").  You may not use this file
@@ -93,8 +94,8 @@ public final class XmlUtil {
 
     /**
      * Return the value of an attribute on an element.
-     * <p/>
-     * The DOM getAttribute method returns an empty string if the attribute
+     *
+     * <p>The DOM getAttribute method returns an empty string if the attribute
      * doesn't exist. Here, we detect this and return null.
      */
     public static String getAttribute(Element e, String name) {
@@ -213,17 +214,17 @@ public final class XmlUtil {
 
     /**
      * Return the content of the given element.
-     * <p/>
-     * We will descend to an arbitrary depth looking for the first text node.
-     * <p/>
-     * Note that the parser may break what was originally a single string of
+     *
+     * <p>We will descend to an arbitrary depth looking for the first text node.
+     *
+     * <p>Note that the parser may break what was originally a single string of
      * pcdata into multiple adjacent text nodes. Xerces appears to do this when
      * it encounters a '$' in the text, not sure if there is specified behavior,
      * or if its parser specific.
-     * <p/>
-     * Here, we will congeal adjacent text nodes.
-     * <p/>
-     * We will NOT ignore text nodes that have only whitespace.
+     *
+     * <p>Here, we will congeal adjacent text nodes.
+     *
+     * <p>We will NOT ignore text nodes that have only whitespace.
      */
     public static String getContent(Element e) {
 

--- a/connector-framework/src/main/java/org/identityconnectors/common/l10n/CurrentLocale.java
+++ b/connector-framework/src/main/java/org/identityconnectors/common/l10n/CurrentLocale.java
@@ -20,6 +20,7 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
  * Portions Copyrighted 2013 ConnId
+ * Portions Copyright 2018 Wren Security.
  */
 package org.identityconnectors.common.l10n;
 
@@ -29,8 +30,8 @@ import java.util.Locale;
  * Thread local variable that impacts localization of all messages in the
  * connector framework. This is roughly equivalent to .Net's
  * Thread.CurrentCulture.
- * <p/>
- * Note that this is an inheritable thread local so it is automatically
+ *
+ * <p>Note that this is an inheritable thread local so it is automatically
  * inherited from parent to child thread. Of course, if the child thread is part
  * of a thread pool, you will still need to manually propagate from parent to
  * child.

--- a/connector-framework/src/main/java/org/identityconnectors/framework/api/APIConfiguration.java
+++ b/connector-framework/src/main/java/org/identityconnectors/framework/api/APIConfiguration.java
@@ -3,6 +3,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms of the Common Development
  * and Distribution License("CDDL") (the "License").  You may not use this file
@@ -56,7 +57,6 @@ public interface APIConfiguration {
      * 
      * @param changeListener
      *            the callback handler to receive the change event.
-     * @return a closeable to unregister the change listener.
      */
    void setChangeListener(ConfigurationPropertyChangeListener changeListener);
 

--- a/connector-framework/src/main/java/org/identityconnectors/framework/api/ConnectorInfoManagerFactory.java
+++ b/connector-framework/src/main/java/org/identityconnectors/framework/api/ConnectorInfoManagerFactory.java
@@ -3,6 +3,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms of the Common Development
  * and Distribution License("CDDL") (the "License").  You may not use this file
@@ -96,8 +97,8 @@ public abstract class ConnectorInfoManagerFactory {
      * NOTICE: This method is an early specification of the Events API for
      * 1.2.x.x version. Use carefully, this package may change before the final
      * 1.2.0.0 release.
-     * <p/>
-     * As now the {@code ConnectorInfoManager} MUST implement the
+     *
+     * <p>As now the {@code ConnectorInfoManager} MUST implement the
      * {@link Runnable} to connect to the remote connector server. <b>NOTE:</b>
      * The results from this call are automatically cached and keyed by the
      * RemoteFrameworkConnectionInfo passed in. To clear the cache, call

--- a/connector-framework/src/main/java/org/identityconnectors/framework/api/operations/batch/CreateBatchTask.java
+++ b/connector-framework/src/main/java/org/identityconnectors/framework/api/operations/batch/CreateBatchTask.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -64,16 +65,10 @@ public class CreateBatchTask implements BatchTask<Uid> {
         this.options = options;
     }
 
-    /**
-     * @{inherit}
-     */
     public Uid execute(BatchTaskExecutor executor) {
         return executor.execute(this);
     }
 
-    /**
-     * @{inherit}
-     */
     public ObjectClass getObjectClass() {
         return objectClass;
     }

--- a/connector-framework/src/main/java/org/identityconnectors/framework/api/operations/batch/DeleteBatchTask.java
+++ b/connector-framework/src/main/java/org/identityconnectors/framework/api/operations/batch/DeleteBatchTask.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -54,16 +55,10 @@ public class DeleteBatchTask implements BatchTask<BatchEmptyResult> {
         this.options = options;
     }
 
-    /**
-     * @{inherit}
-     */
     public BatchEmptyResult execute(BatchTaskExecutor executor) {
         return executor.execute(this);
     }
 
-    /**
-     * @{inherit}
-     */
     public ObjectClass getObjectClass() {
         return objectClass;
     }

--- a/connector-framework/src/main/java/org/identityconnectors/framework/api/operations/batch/UpdateBatchTask.java
+++ b/connector-framework/src/main/java/org/identityconnectors/framework/api/operations/batch/UpdateBatchTask.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -72,9 +73,6 @@ public class UpdateBatchTask implements BatchTask<Uid> {
         this.updateType = type;
     }
 
-    /**
-     * @{inherit}
-     */
     public Uid execute(BatchTaskExecutor executor) {
         return executor.execute(this);
     }
@@ -83,9 +81,6 @@ public class UpdateBatchTask implements BatchTask<Uid> {
         return updateType;
     }
 
-    /**
-     * @{inherit}
-     */
     public ObjectClass getObjectClass() {
         return objectClass;
     }

--- a/connector-framework/src/main/java/org/identityconnectors/framework/common/exceptions/InvalidCredentialException.java
+++ b/connector-framework/src/main/java/org/identityconnectors/framework/common/exceptions/InvalidCredentialException.java
@@ -3,6 +3,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms of the Common Development
  * and Distribution License("CDDL") (the "License").  You may not use this file
@@ -24,10 +25,10 @@ package org.identityconnectors.framework.common.exceptions;
 
 /**
  * InvalidCredentialException signals that user authentication failed.
- * <p/>
- * This exception is thrown by Connector if authentication failed. For example,
- * a <code>Connector</code> throws this exception if the user entered an
- * incorrect password.
+ *
+ * <p>This exception is thrown by Connector if authentication failed. For
+ * example, a <code>Connector</code> throws this exception if the user entered
+ * an incorrect password.
  *
  * @see javax.security.auth.login.FailedLoginException
  */

--- a/connector-framework/src/main/java/org/identityconnectors/framework/common/exceptions/RetryableException.java
+++ b/connector-framework/src/main/java/org/identityconnectors/framework/common/exceptions/RetryableException.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2013 ForgeRock AS. All Rights Reserved
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -30,8 +31,6 @@ import org.identityconnectors.framework.common.objects.Uid;
 /**
  * RetryableException indicates that a failure may be temporary, and that
  * retrying the same request may be able to succeed in the future.
- * <p/>
- *
  *
  * @author Laszlo Hordos
  * @since 1.4
@@ -115,10 +114,10 @@ public class RetryableException extends ConnectorException {
      * was created with <code>Uid</code> and Application should call the
      * {@link org.identityconnectors.framework.spi.operations.UpdateOp#update(org.identityconnectors.framework.common.objects.ObjectClass, org.identityconnectors.framework.common.objects.Uid, java.util.Set, org.identityconnectors.framework.common.objects.OperationOptions)}
      * method now.
-     * <p/>
-     * Use this only if the created object can not be deleted. The best-practice
-     * should always be the Connector implementation reverts the changes if the
-     * operation failed.
+     *
+     * <p>Use this only if the created object can not be deleted. The
+     * best-practice should always be the Connector implementation reverts the
+     * changes if the operation failed.
      *
      * @param message
      *            the detail message (which is saved for later retrieval by the

--- a/connector-framework/src/main/java/org/identityconnectors/framework/common/exceptions/UnknownUidException.java
+++ b/connector-framework/src/main/java/org/identityconnectors/framework/common/exceptions/UnknownUidException.java
@@ -3,6 +3,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms of the Common Development
  * and Distribution License("CDDL") (the "License").  You may not use this file
@@ -28,8 +29,8 @@ import org.identityconnectors.framework.common.objects.Uid;
 /**
  * Thrown when a {@link Uid} that is specified as input to a connector operation
  * identifies no object on the target resource.
- * <p/>
- * When implementing {@code AuthenticateOp} this exception may be thrown by a
+ *
+ * <p>When implementing {@code AuthenticateOp} this exception may be thrown by a
  * Connector if it is unable to locate an account necessary to perform
  * authentication.
  *

--- a/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/Schema.java
+++ b/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/Schema.java
@@ -3,6 +3,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms of the Common Development
  * and Distribution License("CDDL") (the "License").  You may not use this file
@@ -46,7 +47,7 @@ import org.identityconnectors.framework.common.serializer.SerializerUtil;
  * <li>Supported ObjectClasses by operation (
  * {@link #getSupportedObjectClassesByOperation()}).</li>
  * <li>Supported OperationOptionInfo by operation(
- * {@link #getSupportedOptionsByOperation()()}).</li>
+ * {@link #getSupportedOptionsByOperation()}).</li>
  * </ol>
  *
  * TODO: add more to describe and what is expected from this call and how it is

--- a/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/SyncDeltaType.java
+++ b/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/SyncDeltaType.java
@@ -3,6 +3,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms of the Common Development
  * and Distribution License("CDDL") (the "License").  You may not use this file
@@ -48,8 +49,9 @@ public enum SyncDeltaType {
 
     /**
      * The change represents a CREATE in the resource.
-     * <p/>
-     * Experimental type to support better event mechanism where it's possible.
+     *
+     * <p>Experimental type to support better event mechanism where it's
+     * possible.
      *
      * @see #CREATE_OR_UPDATE
      * @since 1.4
@@ -58,8 +60,9 @@ public enum SyncDeltaType {
 
     /**
      * The change represents a UPDATE in the resource.
-     * <p/>
-     * Experimental type to support better event mechanism where it's possible.
+     *
+     * <p>Experimental type to support better event mechanism where it's
+     * possible.
      *
      * @see #CREATE_OR_UPDATE
      * @since 1.4

--- a/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/Uid.java
+++ b/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/Uid.java
@@ -3,6 +3,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms of the Common Development
  * and Distribution License("CDDL") (the "License").  You may not use this file
@@ -36,8 +37,8 @@ import org.identityconnectors.framework.api.operations.UpdateApiOp;
  * A single-valued attribute that represents the <i>unique identifier</i> of an
  * object within the name-space of the target resource. If possible, this unique
  * identifier also should be immutable.
- * <p/>
- * When an application creates an object on a target resource, the
+ *
+ * <p>When an application creates an object on a target resource, the
  * {@link CreateApiOp#create create} operation returns as its result the
  * <code>Uid</code> of the created object. An application also can use the
  * {@link SearchApiOp#search search} operation to discover the <code>Uid</code>
@@ -46,8 +47,8 @@ import org.identityconnectors.framework.api.operations.UpdateApiOp;
  * {@link GetApiOp#getObject get}, {@link DeleteApiOp#delete delete} or
  * {@link UpdateApiOp#update update} that object. See the documentation for
  * {@link Name} for comparison.
- * <p/>
- * Ideally, the value of <code>Uid</code> would be a <i>Globally Unique
+ *
+ * <p>Ideally, the value of <code>Uid</code> would be a <i>Globally Unique
  * IDentifier (GUID)</i>. However, not every target resource provides a globally
  * unique and immutable identifier for each of its objects. For some connector
  * implementations, therefore, the <code>Uid</code> value is only <i>locally</i>
@@ -58,17 +59,17 @@ import org.identityconnectors.framework.api.operations.UpdateApiOp;
  * the <code>Uid</code> of an object. The fact that changing an object might
  * change its <code>Uid</code> is the reason that {@link UpdateApiOp#update
  * update} returns <code>Uid</code>.
- * <p/>
- * {@link Uid} by definition must be a single-valued attribute. Its value must
- * always convert to a string, regardless of the underlying type of the native
- * identifier on the target. The string value of any native id must be
+ *
+ * <p>{@link Uid} by definition must be a single-valued attribute. Its value
+ * must always convert to a string, regardless of the underlying type of the
+ * native identifier on the target. The string value of any native id must be
  * canonical.
- * <p/>
- * Uid is never allowed to appear in the {@link Schema}, nor may Uid appear in
- * the attribute set of a {@link CreateApiOp#create create} operation. This is
- * because Uid is not a true attribute of an object, but rather a reference to
- * that object. Uid extends {@link Attribute} only so that Uid can be searchable
- * and compatible with the filter translators.
+ *
+ * <p>Uid is never allowed to appear in the {@link Schema}, nor may Uid appear
+ * in the attribute set of a {@link CreateApiOp#create create} operation. This
+ * is because Uid is not a true attribute of an object, but rather a reference
+ * to that object. Uid extends {@link Attribute} only so that Uid can be
+ * searchable and compatible with the filter translators.
  */
 public final class Uid extends Attribute {
 
@@ -112,8 +113,8 @@ public final class Uid extends Attribute {
 
     /**
      * Return the string representation of the revision value of the
-     * <p/>
-     * The revision number specifies a given version ot the
+     *
+     * <p>The revision number specifies a given version of the
      * {@link ConnectorObject object} identified by the
      * {@link org.identityconnectors.framework.common.objects.Uid#getUidValue()}
      *

--- a/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/filter/AbstractFilterTranslator.java
+++ b/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/filter/AbstractFilterTranslator.java
@@ -20,6 +20,7 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
  * Portions Copyrighted 2015 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
 package org.identityconnectors.framework.common.objects.filter;
 
@@ -80,7 +81,7 @@ abstract public class AbstractFilterTranslator<T> implements FilterTranslator<T>
      *            The filter to translate.
      * @return The list of queries to be performed. The list <code>size()</code>
      *         may be one of the following:
-     *         <ol>
+     *         <ul>
      *         <li>0 - This signifies <b>fetch everything</b>. This may occur if
      *         your filter was null or one of your <code>create*</code> methods
      *         returned null.</li>
@@ -91,7 +92,7 @@ abstract public class AbstractFilterTranslator<T> implements FilterTranslator<T>
      *         behavior standpoint since <code>ConnectorFacade</code> performs a
      *         second level of filtering. However it is undesirable from a
      *         performance standpoint.</li>
-     *         <li>>1 - List contains multiple queries that must be performed in
+     *         <li>&gt;1 - List contains multiple queries that must be performed in
      *         order to meet the filter that was passed in. Note that this only
      *         occurs if your {@link #createOrExpression} method can return
      *         null. If this happens, it is the responsibility of the connector
@@ -101,7 +102,7 @@ abstract public class AbstractFilterTranslator<T> implements FilterTranslator<T>
      *         been visited thus far. This will not scale well if your result
      *         sets are large. Therefore it is <b>recommended</b> that if at all
      *         possible you implement {@link #createOrExpression}</li>
-     *         </ol>
+     *         </ul>
      */
     public final List<T> translate(Filter filter) {
         if (filter == null) {

--- a/connector-framework/src/main/java/org/identityconnectors/framework/spi/StatefulConfiguration.java
+++ b/connector-framework/src/main/java/org/identityconnectors/framework/spi/StatefulConfiguration.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2013 ForgeRock AS. All Rights Reserved
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -27,8 +28,8 @@ package org.identityconnectors.framework.spi;
 /**
  * A Stateful Configuration interface extends the default {@link Configuration}
  * and makes the framework keep the same instance.
- * <p/>
- * The default Configuration object instance is constructed every single time
+ *
+ * <p>The default Configuration object instance is constructed every single time
  * before the {@link Connector#init(Configuration)} is called. If the
  * configuration class implements this interface then the Framework keeps one
  * instance of Configuration and the {@link Connector#init(Configuration)} is
@@ -39,12 +40,11 @@ package org.identityconnectors.framework.spi;
  * Connector developer must quarantine that the necessary resource
  * initialisation are thread-safe.
  *
- * <p/>
- * If the connector implements the {@link PoolableConnector} then this
+ * <p>If the connector implements the {@link PoolableConnector} then this
  * configuration is kept in the
- * {@link org.identityconnectors.framework.impl.api.local.ConnectorPoolManager}
- * and when the
- * {@link org.identityconnectors.framework.impl.api.local.ConnectorPoolManager#dispose()}
+ * {@code org.identityconnectors.framework.impl.api.local.ConnectorPoolManager}
+ * and when
+ * {@code ConnectorPoolManager.dispose()}
  * calls the {@link #release()} method. If the connector implements only the
  * {@link Connector} then this configuration is kept in the
  * {@link org.identityconnectors.framework.api.ConnectorFacade} and the

--- a/connector-framework/src/main/java/org/identityconnectors/framework/spi/package-info.java
+++ b/connector-framework/src/main/java/org/identityconnectors/framework/spi/package-info.java
@@ -3,6 +3,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms of the Common Development
  * and Distribution License("CDDL") (the "License").  You may not use this file
@@ -22,31 +23,44 @@
  */
 
 /**
- * This is the "Service Provider Interface" package.  The {@link org.identityconnectors.framework.spi.Connector} developer
- * is responsible for implementing the following interfaces to build a {@link org.identityconnectors.framework.spi.Connector}.
- * <ul>
- * <li>First, one must implement the {@link org.identityconnectors.framework.spi.Configuration} interface.
- * The {@link org.identityconnectors.framework.spi.Configuration#validate} method is used to determine
- * whether the configuration information that has been provided is valid.  The implementation should simply be a Java Bean.
- * There should be a getter and setter for each configuration property. For instance, if the resource is a database instance
- * then some typical configuration information would include the JDBC driver, the host name of remote machine or the URL,
- * and some connection credentials.  The getter should return the default value.
+ * This is the "Service Provider Interface" package.  The
+ * {@link org.identityconnectors.framework.spi.Connector} developer
+ * is responsible for implementing the following interfaces to build a
+ * {@link org.identityconnectors.framework.spi.Connector}.
+ * <ol>
+ * <li>One must implement the
+ * {@link org.identityconnectors.framework.spi.Configuration} interface. The
+ * {@link org.identityconnectors.framework.spi.Configuration#validate} method is
+ * used to determine whether the configuration information that has been
+ * provided is valid.  The implementation should simply be a Java Bean. There
+ * should be a getter and setter for each configuration property. For instance,
+ * if the resource is a database instance then some typical configuration
+ * information would include the JDBC driver, the host name of remote machine or
+ * the URL, and some connection credentials.  The getter should return the
+ * default value.
  * </li>
- * <li>Second, one should implement the {@link org.identityconnectors.framework.spi.Connector} interface.
- * This interface insures proper initialization and disposal of the {@link org.identityconnectors.framework.spi.Connector}.
- * If the {@link org.identityconnectors.framework.spi.Connector} developer would like the API to handle 'Connection Pooling',
- * the Connector must implement the {@link org.identityconnectors.framework.spi.PoolableConnector} interface.
+ * <li>One should implement the
+ * {@link org.identityconnectors.framework.spi.Connector} interface. This
+ * interface insures proper initialization and disposal of the
+ * {@link org.identityconnectors.framework.spi.Connector}. If the
+ * {@link org.identityconnectors.framework.spi.Connector} developer would like
+ * the API to handle 'Connection Pooling', the Connector must implement the
+ * {@link org.identityconnectors.framework.spi.PoolableConnector} interface.
  * </li>
- * <li>Third, one should implement all the operations the resource can support, such as
+ * <li>One should implement all the operations the resource can support,
+ * such as
  * {@link org.identityconnectors.framework.spi.operations.CreateOp},
  * {@link org.identityconnectors.framework.spi.operations.UpdateOp},
  * {@link org.identityconnectors.framework.spi.operations.DeleteOp},
  * {@link org.identityconnectors.framework.spi.operations.SearchOp}, etc..
- * <p>
- * The {@link org.identityconnectors.framework.spi.operations operations} package
- * has many operations from which to choose. In some cases, one operation does the same thing as another
- * but exposes more options.   For instance there are two update operations.
- * {@link org.identityconnectors.framework.spi.operations.UpdateOp} is simpler to implement than
+ * </ol>
+ *
+ * <p>The {@link org.identityconnectors.framework.spi.operations operations}
+ * package has many operations from which to choose. In some cases, one
+ * operation does the same thing as another but exposes more options. For
+ * instance there are two update operations.
+ * {@link org.identityconnectors.framework.spi.operations.UpdateOp} is simpler
+ * to implement than
  * {@link org.identityconnectors.framework.spi.operations.UpdateAttributeValuesOp}.
  */
 package org.identityconnectors.framework.spi;

--- a/connector-server-grizzly/pom.xml
+++ b/connector-server-grizzly/pom.xml
@@ -3,6 +3,7 @@
  DO NOT REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright (c) 2015 ForgeRock AS. All rights reserved.
+ Portions Copyright 2017 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -32,9 +33,10 @@
 
     <artifactId>connector-server-grizzly</artifactId>
     <packaging>bundle</packaging>
-    <name>OpenICF Framework - Grizzly Server</name>
+    <name>Wren:ICF - Server - Grizzly Integration</name>
     <description>
-
+        Provides Connectors with the ability to run a Connector as a standalone servlet on top of
+        Grizzly.
     </description>
 
     <properties>
@@ -50,21 +52,25 @@
             <artifactId>connector-framework-server</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-framework</artifactId>
             <version>${grizzly.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http-servlet</artifactId>
             <version>${grizzly.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-websockets</artifactId>
             <version>${grizzly.version}</version>
         </dependency>
+
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
@@ -77,12 +83,14 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.easytesting</groupId>
             <artifactId>fest-assert</artifactId>
             <version>1.4</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.openicf.framework</groupId>
             <artifactId>connector-framework-server</artifactId>
@@ -90,29 +98,34 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>${groovy.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>io.reactivex</groupId>
             <artifactId>rxjava</artifactId>
             <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.openicf.framework</groupId>
             <artifactId>testbundlev1</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.littleshoot</groupId>
             <artifactId>littleproxy</artifactId>
             <version>1.1.0</version>
             <scope>test</scope>
+
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -120,40 +133,47 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+
                 <executions>
                     <execution>
                         <id>build-test-jar</id>
+
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+
                 <configuration>
                     <instructions>
                     </instructions>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+
                 <configuration>
                     <excludes>
                         <exclude>**/AsyncDotNetPlainConnectorInfoManagerTest.java</exclude>

--- a/connector-server-grizzly/src/main/java/org/forgerock/openicf/framework/server/ConnectorServer.java
+++ b/connector-server-grizzly/src/main/java/org/forgerock/openicf/framework/server/ConnectorServer.java
@@ -2,6 +2,7 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
  * Copyright (c) 2015 ForgeRock AS. All rights reserved.
+ * Portions Copyright 2018 Wren Security.
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -258,7 +259,7 @@ public class ConnectorServer {
      * operation must be performed in the <code>start()</code> method.
      * </p>
      *
-     * @exception Exception
+     * @throws Exception
      *                Any exception preventing a successful initialization.
      */
     public void init() throws Exception {
@@ -352,9 +353,6 @@ public class ConnectorServer {
 
     /**
      * create SSL Configuration
-     *
-     * @return
-     * @throws Exception
      */
     protected SSLEngineConfigurator createSSLConfig(final SSLContextConfigurator contextConfigurator) {
 

--- a/connector-server-jetty/pom.xml
+++ b/connector-server-jetty/pom.xml
@@ -3,6 +3,7 @@
  DO NOT REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright (c) 2010-2016 ForgeRock AS. All rights reserved.
+ Portions Copyright 2017 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -23,18 +24,21 @@
  "Portions Copyrighted [year] [name of copyright owner]"
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>framework</artifactId>
         <groupId>org.forgerock.openicf.framework</groupId>
         <version>1.5.2.0</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>connector-server-jetty</artifactId>
     <packaging>bundle</packaging>
-    <name>OpenICF Framework - Jetty Server</name>
-    <description>
 
+    <name>Wren:ICF - Server - Jetty Integration</name>
+    <description>
+        Provides Connectors with the ability to run a Connector as a standalone servlet on top of
+        Jetty.
     </description>
 
     <properties>
@@ -51,6 +55,7 @@
             <artifactId>connector-framework-server</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-server</artifactId>
@@ -70,12 +75,14 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.easytesting</groupId>
             <artifactId>fest-assert</artifactId>
             <version>1.4</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.openicf.framework</groupId>
             <artifactId>connector-framework-server</artifactId>
@@ -83,30 +90,35 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>${groovy.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>io.reactivex</groupId>
             <artifactId>rxjava</artifactId>
             <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.openicf.framework</groupId>
             <artifactId>testbundlev1</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
             <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
@@ -114,12 +126,14 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+
                 <configuration>
                     <instructions>
                     </instructions>

--- a/connector-server-jetty/src/main/java/org/forgerock/openicf/framework/server/jetty/OpenICFWebSocketServletBase.java
+++ b/connector-server-jetty/src/main/java/org/forgerock/openicf/framework/server/jetty/OpenICFWebSocketServletBase.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
 
 package org.forgerock.openicf.framework.server.jetty;
@@ -143,8 +144,6 @@ public class OpenICFWebSocketServletBase extends WebSocketServlet {
 
     /**
      * Overwrite with custom implementation.
-     *
-     * @return
      */
     protected void configure(ConnectorFramework connectorFramework) {
         logger.info("Implementation should overwrite this method");

--- a/connector-test-common/pom.xml
+++ b/connector-test-common/pom.xml
@@ -3,6 +3,7 @@
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright (c) 2010-2015 ForgeRock AS. All rights reserved.
+ Portions Copyright 2017 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -24,24 +25,30 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.forgerock.openicf.framework</groupId>
         <artifactId>framework</artifactId>
         <version>1.5.2.0</version>
     </parent>
+
     <artifactId>connector-test-common</artifactId>
-    <name>OpenICF Common Test Library</name>
-    <description>TestHelpers is a helper class to simplify the testing of connectors.</description>
+
+    <name>Wren:ICF - Common Test Library</name>
+    <description>Provides common helper classes to simplify the testing of connectors.</description>
+
     <dependencies>
         <dependency>
             <groupId>org.forgerock.openicf.framework</groupId>
             <artifactId>connector-framework</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
         </dependency>
+
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
@@ -55,10 +62,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <properties>
-        <!-- If we release this project, we need to include the Forgerock binary license -->
-        <include.binary.license>
-            ${project.build.outputDirectory}/legal-notices
-        </include.binary.license>
-    </properties>
 </project>

--- a/icfl-over-slf4j/pom.xml
+++ b/icfl-over-slf4j/pom.xml
@@ -3,6 +3,7 @@
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright (c) 2010-2015 ForgeRock AS. All rights reserved.
+ Portions Copyright 2017 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -24,14 +25,21 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.forgerock.openicf.framework</groupId>
         <artifactId>framework</artifactId>
         <version>1.5.2.0</version>
     </parent>
+
     <artifactId>icfl-over-slf4j</artifactId>
     <packaging>bundle</packaging>
-    <name>OpenICF Framework - logging over SLF4J</name>
+
+    <name>Wren:ICF - Framework - SLF4J Logging Provider</name>
+    <description>
+        Provides connectors with pre-configured, built-in logging provided by the Simple Logging
+        Facade for Java.
+    </description>
 
     <dependencies>
         <dependency>
@@ -54,6 +62,7 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
@@ -61,18 +70,14 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <properties>
-        <!-- If we release this project, we need to include the Forgerock binary license -->
-        <include.binary.license>
-            ${project.build.directory}/maven-shared-archive-resources/legal-notices
-        </include.binary.license>
-    </properties>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+
                 <configuration>
                     <instructions>
                         <Export-Package>!*</Export-Package>

--- a/openicf-zip/pom.xml
+++ b/openicf-zip/pom.xml
@@ -3,6 +3,7 @@
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright (c) 2010-2015 ForgeRock AS. All rights reserved.
+ Portions Copyright 2017 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -24,57 +25,68 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.forgerock.openicf.framework</groupId>
         <artifactId>framework</artifactId>
         <version>1.5.2.0</version>
     </parent>
+
     <artifactId>openicf-zip</artifactId>
     <packaging>pom</packaging>
-    <name>OpenICF Java ZIP</name>
-    <description>OpenICF Connector server</description>
+
+    <name>Wren:ICF - Java ZIP</name>
+    <description>
+        Packages up the Java-based Wren:ICF Connector framework into a single ZIP archive, ready for
+        distribution.
+    </description>
+
     <dependencies>
         <dependency>
             <groupId>org.forgerock.openicf.framework</groupId>
             <artifactId>connector-framework-internal</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.openicf.framework</groupId>
             <artifactId>connector-server-grizzly</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.forgerock.openicf.framework</groupId>
             <artifactId>icfl-over-slf4j</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <scope>compile</scope>
         </dependency>
-    </dependencies> 
-    <properties>
-        <!-- If we release this project, we need to include the Forgerock binary license -->
-        <include.binary.license>${project.build.directory}</include.binary.license>
-    </properties>
+    </dependencies>
+
     <build>
         <finalName>openicf-${project.version}</finalName>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-remote-resources-plugin</artifactId>
+
                 <executions>
                     <execution>
                         <goals>
                             <goal>process</goal>
                         </goals>
+
                         <configuration>
                             <resourceBundles>
                                 <resourceBundle>${licenseResourceBundle}</resourceBundle>
@@ -83,19 +95,24 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
+
                     <descriptors>
                         <descriptor>src/assembly/zip.xml</descriptor>
                     </descriptors>
                 </configuration>
+
                 <executions>
                     <execution>
                         <id>zip-assembly</id>
                         <phase>package</phase>
+
                         <goals>
                             <goal>single</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,7 @@
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright (c) 2010-2015 ForgeRock AS. All rights reserved.
+ Portions Copyright 2017 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -24,32 +25,40 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.forgerock</groupId>
         <artifactId>forgerock-parent</artifactId>
         <version>2.0.4</version>
     </parent>
+
     <groupId>org.forgerock.openicf.framework</groupId>
     <artifactId>framework</artifactId>
     <version>1.5.2.0</version>
     <packaging>pom</packaging>
-    <name>OpenICF</name>
+
+    <name>Wren:ICF</name>
     <description>
-        The Open Identity Connectors Framework and Toolkit (OpenICF) is built to help drive development of Connectors.
-        Connectors provide a consistent generic layer between applications and target resources.
+        The Wren Security Identity Connectors Framework and Toolkit (Wren:ICF) is built to help
+        drive development of Connectors. Connectors provide a consistent generic layer between
+        applications that consume identity information and resources that store and maintain
+        identity information.
     </description>
-    <inceptionYear>2010</inceptionYear>
-    <url>http://openicf.forgerock.org/</url>
+
+    <inceptionYear>2017</inceptionYear>
+    <url>https://github.com/WrenSecurity/wrenicf-java-framework</url>
+
     <licenses>
         <license>
             <name>CDDL-1.0</name>
             <url>http://opensource.org/licenses/CDDL-1.0</url>
             <comments>Common Development and Distribution License (CDDL) 1.0.
-                This license applies to OpenICF source code as indicated in the
+                This license applies to Wren:ICF source code as indicated in the
                 sources.
             </comments>
             <distribution>repo</distribution>
         </license>
+
         <license>
             <name>CC BY-NC-ND 3.0</name>
             <url>http://creativecommons.org/licenses/by-nc-nd/3.0/</url>
@@ -60,88 +69,44 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
-    <scm>
-        <connection>scm:git:ssh://git@stash.forgerock.org:7999/openicf/java-framework.git</connection>
-        <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/openicf/java-framework.git</developerConnection>
-        <url>http://stash.forgerock.org/projects/OPENICF/repos/java-framework/browse</url>
-      <tag>1.5.2.0</tag>
-  </scm>
-    <distributionManagement>
-        <site>
-            <id>forgerock.org</id>
-            <name>ForgeRock Community Server</name>
-            <url>${siteDistributionURL}</url>
-        </site>
-    </distributionManagement>
 
-    <!-- (see FAQ at http://maven.apache.org/guides/mini/guide-central-repository-upload.html ) -->
+    <scm>
+        <url>https://github.com/WrenSecurity/wrenicf-java-framework</url>
+        <connection>scm:git:git://github.com/WrenSecurity/wrenicf-java-framework.git</connection>
+        <developerConnection>scm:git:git@github.com:WrenSecurity/wrenicf-java-framework.git</developerConnection>
+    </scm>
+
     <repositories>
+        <!-- Needed to retrieve parent POM -->
         <repository>
-            <id>forgerock-staging-repository</id>
-            <name>ForgeRock Release Repository</name>
-            <url>http://maven.forgerock.org/repo/releases</url>
+            <id>wrensecurity-releases</id>
+            <name>Wren Security Release Repository</name>
+            <url>https://wrensecurity.jfrog.io/wrensecurity/releases</url>
+
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-        </repository>
-        <repository>
-            <id>forgerock-snapshots-repository</id>
-            <name>ForgeRock Snapshot Repository</name>
-            <url>http://maven.forgerock.org/repo/snapshots</url>
+
             <releases>
-                <enabled>false</enabled>
+                <enabled>true</enabled>
             </releases>
         </repository>
     </repositories>
 
     <mailingLists>
         <mailingList>
-            <name>OpenICF: Technical communications</name>
-            <post>openicf@forgerock.org</post>
-            <subscribe>https://lists.forgerock.org/mailman/listinfo/openicf</subscribe>
-            <unsubscribe>https://lists.forgerock.org/mailman/listinfo/openicf</unsubscribe>
-            <archive>https://lists.forgerock.org/pipermail/openicf/</archive>
-        </mailingList>
-        <mailingList>
-            <name>OpenICF: Commit Notifications</name>
-            <post>commitopenicf@forgerock.org</post>
-            <subscribe>https://lists.forgerock.org/mailman/listinfo/commitopenicf</subscribe>
-            <unsubscribe>https://lists.forgerock.org/mailman/listinfo/commitopenicf</unsubscribe>
-            <archive>https://lists.forgerock.org/pipermail/commitopenicf/</archive>
-        </mailingList>
-        <mailingList>
-            <name>OpenICF: Developers</name>
-            <post>openicf-dev@forgerock.org</post>
-            <subscribe>https://lists.forgerock.org/mailman/listinfo/openicf-dev</subscribe>
-            <unsubscribe>https://lists.forgerock.org/mailman/listinfo/openicf-dev</unsubscribe>
-            <archive>https://lists.forgerock.org/pipermail/openicf-dev/</archive>
+            <name>Wren Security Mailing List</name>
+            <archive>https://groups.google.com/forum/#!forum/wren-security</archive>
+            <subscribe>https://groups.google.com/forum/#!forum/wren-security</subscribe>
+            <unsubscribe>https://groups.google.com/forum/#!forum/wren-security</unsubscribe>
+            <post>wren-security@googlegroups.com</post>
         </mailingList>
     </mailingLists>
 
     <issueManagement>
-        <system>jira</system>
-        <url>https://bugster.forgerock.org/jira/browse/OPENICF/component/10192</url>
+        <system>GitHub Issues</system>
+        <url>https://github.com/WrenSecurity/WrenIDM/issues</url>
     </issueManagement>
-
-    <ciManagement>
-        <system>jenkins</system>
-        <url>https://ci.forgerock.org/view/OpenICF/job/OpenICF - java-framework - postcommit/</url>
-    </ciManagement>
-
-    <developers>
-        <developer>
-            <id>forgerock</id>
-            <name>OpenICF Community</name>
-            <email>openicf@forgerock.org</email>
-            <organization>ForgeRock</organization>
-            <roles>
-                <role>Architect</role>
-                <role>Release Manager</role>
-                <role>Java Developer</role>
-            </roles>
-            <timezone>+1</timezone>
-        </developer>
-    </developers>
 
     <properties>
         <!-- Version management -->
@@ -152,15 +117,13 @@
         <framework.compatibilityVersion>1.5</framework.compatibilityVersion>
         <framework.releaseVersion>1.0</framework.releaseVersion>
         <licenseResourceBundle>org.forgerock.openicf:openicf-license:1.3.0</licenseResourceBundle>
-        <siteDistributionURL>scp://community.internal.forgerock.com/var/www/vhosts/openicf.forgerock.org/httpdocs
-        </siteDistributionURL>
 
         <openicf.osgi.remove.headers>
             Ignore-Package,Include-Resource,Private-Package,Bundle-DocURL,Embedded-Artifacts,Embed-Dependency,Built-By,
             Build-Jdk,Tool
         </openicf.osgi.remove.headers>
 
-        <openicf.maven.plugin.version>1.5.0-RC1</openicf.maven.plugin.version>
+        <openicf.maven.plugin.version>1.5.0</openicf.maven.plugin.version>
         <slf4j.version>1.7.12</slf4j.version>
         <logback.version>1.1.7</logback.version>
         <groovy.version>2.2.2</groovy.version>
@@ -170,7 +133,7 @@
         <!-- Core documentation properties -->
         <frDocPluginVersion>3.1.0</frDocPluginVersion>
         <docTargetVersion>${project.version}</docTargetVersion>
-        <googleAnalyticsAccountId>UA-23412190-10</googleAnalyticsAccountId>
+        <googleAnalyticsAccountId />
         <!--
             Release date is specified only when building the documentation
             for publication. For example:
@@ -189,7 +152,6 @@
         <brandingGroupId>org.forgerock.commons</brandingGroupId>
         <brandingArtifactId>forgerock-doc-default-branding</brandingArtifactId>
         <brandingVersion>3.1.0</brandingVersion>
-
     </properties>
 
     <modules>
@@ -209,34 +171,42 @@
     <profiles>
         <profile>
             <id>1.5.profile</id>
+
             <properties>
                 <!-- forgerock-build-tools stylesheet org/forgerock/javadoc/javadoc.css
                 does not work with JDK7 -->
                 <javadocStylesheet>org/forgerock/javadoc/javadoc.css</javadocStylesheet>
             </properties>
+
             <activation>
                 <jdk>1.5</jdk>
             </activation>
         </profile>
+
         <profile>
             <id>1.6.profile</id>
+
             <properties>
                 <!-- forgerock-build-tools stylesheet org/forgerock/javadoc/javadoc.css
                 does not work with JDK7 -->
                 <javadocStylesheet>org/forgerock/javadoc/javadoc.css</javadocStylesheet>
             </properties>
+
             <modules>
                 <module>connector-framework-protobuf</module>
                 <module>connector-framework-rpc</module>
                 <module>connector-framework-server</module>
                 <module>connector-server-grizzly</module>
             </modules>
+
             <activation>
                 <jdk>1.6</jdk>
             </activation>
         </profile>
+
         <profile>
             <id>1.7.profile</id>
+
             <modules>
                 <module>connector-framework-protobuf</module>
                 <module>connector-framework-rpc</module>
@@ -244,17 +214,21 @@
                 <module>connector-server-jetty</module>
                 <module>connector-server-grizzly</module>
             </modules>
+
             <activation>
                 <jdk>1.7</jdk>
             </activation>
         </profile>
+
         <profile>
             <id>1.8.profile</id>
+
             <properties>
                 <!-- forgerock-build-tools stylesheet org/forgerock/javadoc/javadoc.css
                 does not work with JDK7 -->
                 <javadocStylesheet>org/forgerock/javadoc/javadoc.css</javadocStylesheet>
             </properties>
+
             <modules>
                 <module>connector-framework-protobuf</module>
                 <module>connector-framework-rpc</module>
@@ -262,28 +236,34 @@
                 <module>connector-server-jetty</module>
                 <module>connector-server-grizzly</module>
             </modules>
+
             <activation>
                 <jdk>1.8</jdk>
             </activation>
         </profile>
+
         <profile>
             <id>forgerock-release</id>
+
             <build>
                 <resources>
                     <resource>
                         <directory>src/main/resources</directory>
                         <filtering>true</filtering>
                     </resource>
+
                     <resource>
                         <directory>${project.build.directory}/licenseResource</directory>
                         <filtering>false</filtering>
                     </resource>
                 </resources>
+
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-release-plugin</artifactId>
                         <version>2.5.2</version>
+
                         <configuration>
                             <mavenExecutorId>forked-path</mavenExecutorId>
                             <autoVersionSubmodules>true</autoVersionSubmodules>
@@ -329,12 +309,14 @@
                 <type>test-jar</type>
                 <scope>test</scope>
             </dependency>
+
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
                 <version>6.9.10</version>
                 <scope>test</scope>
             </dependency>
+
             <dependency>
                 <groupId>org.easytesting</groupId>
                 <artifactId>fest-assert</artifactId>
@@ -351,6 +333,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.19</version>
+
                     <configuration>
                         <includes>
                             <include>**/Test*.java</include>
@@ -360,47 +343,57 @@
                         </includes>
                     </configuration>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>2.10.3</version>
+
                     <configuration>
                         <docfilessubdirs>true</docfilessubdirs>
                         <source>${maven.compiler.source}</source>
                         <show>public</show>
+
                         <links>
                             <link>http://docs.oracle.com/javase/6/docs/api/</link>
                             <link>http://docs.groovy-lang.org/latest/html/api/</link>
                         </links>
                     </configuration>
+
                     <executions>
                         <execution>
                             <id>aggregate</id>
+                            <phase>site</phase>
+
                             <goals>
                                 <goal>aggregate</goal>
                             </goals>
-                            <phase>site</phase>
                         </execution>
                     </executions>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>2.10</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
                     <version>3.4</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
                     <extensions>true</extensions>
+
                     <configuration>
                         <instructions>
                             <!-- OSGi Headers -->
@@ -414,12 +407,14 @@
                         </instructions>
                     </configuration>
                 </plugin>
+
                 <plugin>
                     <groupId>org.forgerock.commons</groupId>
                     <artifactId>forgerock-doc-maven-plugin</artifactId>
                     <version>${frDocPluginVersion}</version>
+
                     <configuration>
-                        <projectName>OpenICF</projectName>
+                        <projectName>Wren:ICF</projectName>
                         <googleAnalyticsId>${googleAnalyticsAccountId}</googleAnalyticsId>
                         <projectVersion>${docTargetVersion}</projectVersion>
                         <releaseVersion>${docTargetVersion}</releaseVersion>
@@ -436,12 +431,15 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-remote-resources-plugin</artifactId>
                 <version>1.5</version>
+
                 <executions>
                     <execution>
                         <id>legal-files</id>
+
                         <goals>
                             <goal>process</goal>
                         </goals>
+
                         <configuration>
                             <resourceBundles>
                                 <resourceBundle>${licenseResourceBundle}</resourceBundle>
@@ -450,32 +448,40 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>3.3</version>
+
                 <executions>
                     <execution>
                         <id>attach-descriptor</id>
+
                         <goals>
                             <goal>attach-descriptor</goal>
                         </goals>
                     </execution>
                 </executions>
+
                 <configuration>
                     <outputEncoding>${project.build.sourceEncoding}</outputEncoding>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.forgerock.maven.plugins</groupId>
                 <artifactId>javadoc-updater-maven-plugin</artifactId>
                 <version>1.0.0</version>
+
                 <executions>
                     <execution>
                         <phase>post-site</phase>
+
                         <goals>
                             <goal>fixjavadoc</goal>
                         </goals>
+
                         <configuration>
                             <directory>${project.reporting.outputDirectory}</directory>
                         </configuration>
@@ -484,12 +490,14 @@
             </plugin>
         </plugins>
     </build>
+
     <reporting>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
                 <version>2.8</version>
+
                 <reportSets>
                     <reportSet>
                         <reports>
@@ -518,9 +526,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.3</version>
+
                 <reportSets>
                     <reportSet>
                         <id>html</id>
+
                         <configuration>
                             <dependencySourceExcludes>
                                 <dependencySourceExclude>*:testcommonv1:*</dependencySourceExclude>
@@ -528,10 +538,12 @@
                                 <dependencySourceExclude>*:testbundlev1:*</dependencySourceExclude>
                                 <dependencySourceExclude>*:testbundlev2:*</dependencySourceExclude>
                             </dependencySourceExcludes>
+
                             <excludePackageNames>
                                 org.identityconnectors.testcommon:org.identityconnectors.testconnector
                             </excludePackageNames>
                         </configuration>
+
                         <reports>
                             <report>aggregate</report>
                         </reports>
@@ -549,10 +561,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <version>2.19</version>
+
                 <reportSets>
                     <reportSet>
                         <id>${project.artifactId}-test-report-only</id>
                         <inherited>true</inherited>
+
                         <reports>
                             <report>report</report>
                         </reports>

--- a/testbundlev1/pom.xml
+++ b/testbundlev1/pom.xml
@@ -3,6 +3,7 @@
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright (c) 2010-2015 ForgeRock AS. All rights reserved.
+ Portions Copyright 2017 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -24,13 +25,20 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.forgerock.openicf.framework</groupId>
         <artifactId>framework</artifactId>
         <version>1.5.2.0</version>
     </parent>
+
+    <name>Wren:ICF - Test Bundle - Connector Fixtures</name>
+    <description>
+        This bundle provides a test harness and stubs that tests in other packages use to test their
+        interactions with Connectors.
+    </description>
+
     <artifactId>testbundlev1</artifactId>
-    <name>testbundlev1</name>
     <packaging>bundle</packaging>
 
     <dependencies>
@@ -54,6 +62,7 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+
                 <configuration>
                     <instructions>
                         <Embed-Dependency>testcommonv1</Embed-Dependency>
@@ -65,15 +74,19 @@
                     </instructions>
                 </configuration>
             </plugin>
+
             <plugin>
                 <artifactId>maven-site-plugin</artifactId>
+
                 <configuration>
                     <generateReports>false</generateReports>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/testbundlev2/pom.xml
+++ b/testbundlev2/pom.xml
@@ -3,6 +3,7 @@
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright (c) 2010-2015 ForgeRock AS. All rights reserved.
+ Portions Copyright 2017 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -24,14 +25,21 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.forgerock.openicf.framework</groupId>
         <artifactId>framework</artifactId>
         <version>1.5.2.0</version>
     </parent>
+
     <artifactId>testbundlev2</artifactId>
-    <name>testbundlev2</name>
     <packaging>bundle</packaging>
+
+    <name>Wren:ICF - Test Bundle - Failure Cases</name>
+    <description>
+        This bundle provides tests in other packages with a way to assert that failures when loading
+        Connectors are handled gracefully.
+    </description>
 
     <dependencies>
         <dependency>
@@ -54,10 +62,12 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+
                 <configuration>
                     <instructions>
                         <Embed-Dependency>testcommonv2</Embed-Dependency>
                         <Embed-Directory>lib</Embed-Directory>
+
                         <!-- http://www.osgi.org/Specifications/Reference -->
                         <Bundle-NativeCode>
                             native/native.dll;osname=Win32;processor=x86,
@@ -65,6 +75,7 @@
                             native/libnative.jnilib;osname=MacOSX;processor=x86,
                             native/libnative.jnilib;osname=MacOSX;processor=ppc
                         </Bundle-NativeCode>
+
                         <ConnectorBundle-FrameworkVersion>1.0</ConnectorBundle-FrameworkVersion>
                         <ConnectorBundle-Name>${project.artifactId}</ConnectorBundle-Name>
                         <ConnectorBundle-Version>2.0.0.0</ConnectorBundle-Version>
@@ -72,15 +83,19 @@
                     </instructions>
                 </configuration>
             </plugin>
+
             <plugin>
                 <artifactId>maven-site-plugin</artifactId>
+
                 <configuration>
                     <generateReports>false</generateReports>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/testcommonv1/pom.xml
+++ b/testcommonv1/pom.xml
@@ -3,6 +3,7 @@
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright (c) 2010-2015 ForgeRock AS. All rights reserved.
+ Portions Copyright 2017 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -24,17 +25,23 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.forgerock.openicf.framework</groupId>
         <artifactId>framework</artifactId>
         <version>1.5.2.0</version>
     </parent>
+
     <artifactId>testcommonv1</artifactId>
-    <name>testcommonv1</name>
+
+    <!-- TODO: Determine why this package exists / what it does. It is seemingly empty... -->
+    <name>Wren:ICF - Test Package Stub (Version 1)</name>
+
     <build>
         <plugins>
             <plugin>
                 <artifactId>maven-site-plugin</artifactId>
+
                 <configuration>
                     <generateReports>false</generateReports>
                 </configuration>

--- a/testcommonv2/pom.xml
+++ b/testcommonv2/pom.xml
@@ -3,6 +3,7 @@
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright (c) 2010-2015 ForgeRock AS. All rights reserved.
+ Portions Copyright 2017 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -24,18 +25,24 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.forgerock.openicf.framework</groupId>
         <artifactId>framework</artifactId>
         <version>1.5.2.0</version>
     </parent>
+
     <artifactId>testcommonv2</artifactId>
-    <name>testcommonv2</name>
     <packaging>jar</packaging>
+
+    <!-- TODO: Determine why this package exists / what it does. It is seemingly empty... -->
+    <name>Wren:ICF - Test Package Stub (Version 2)</name>
+
     <build>
         <plugins>
             <plugin>
                 <artifactId>maven-site-plugin</artifactId>
+
                 <configuration>
                     <generateReports>false</generateReports>
                 </configuration>


### PR DESCRIPTION
- Modifies the OpenICF / Wren:ICF Java SDK POMs to build using Wren's repos.
- Updates branding to call this Wren:ICF instead of OpenICF.
- Removes the FR commercial binary license.
- Adds [Wren Deploy](https://github.com/WrenSecurity/wrensec-deploy-tool) RC file.