### PR TITLE
Upgrade to Commons `22.0.0-M1` and Parent `3.0.0-M2`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright (c) 2010-2015 ForgeRock AS. All rights reserved.
- Portions Copyright 2017 Wren Security.
+ Portions Copyright 2017-2018 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -27,9 +27,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock</groupId>
-        <artifactId>forgerock-parent</artifactId>
-        <version>2.0.4</version>
+        <groupId>org.wrensecurity</groupId>
+        <artifactId>wrensec-parent</artifactId>
+        <version>3.0.0-M2</version>
     </parent>
 
     <groupId>org.forgerock.openicf.framework</groupId>
@@ -110,7 +110,7 @@
 
     <properties>
         <!-- Version management -->
-        <commons.commons-bom.version>21.0.0-alpha-12</commons.commons-bom.version>
+        <commons.commons-bom.version>22.0.0-M1</commons.commons-bom.version>
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.5</maven.compiler.target>
         <maven.compiler.source>1.5</maven.compiler.source>


### PR DESCRIPTION
This makes the project buildable without relying on our binary-only, archived copy of Commons `21.0.0-alpha-23`.

Closes #5.
Closes #6.
Closes #7.
Closes #8.