### PR TITLE
Fix project build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,14 @@ jobs:
         java: [11, 17]
     name: "Java ${{ matrix.java }} build"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'temurin'
       - name: Cache Maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/bundle-parent/pom.xml
+++ b/bundle-parent/pom.xml
@@ -13,7 +13,7 @@
     information: "Portions copyright [year] [name of copyright owner]".
 
     Copyright (c) 2010-2015 ForgeRock AS. All rights reserved.
-    Portions Copyright 2017-2022 Wren Security.
+    Portions Copyright 2017-2025 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -167,14 +167,6 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-
-                    <configuration>
-                        <links>
-                            <link>http://download.oracle.com/javase/8/docs/api/</link>
-                            <link>http://docs.groovy-lang.org/latest/html/api/</link>
-                            <link>http://openicf.forgerock.org/apidocs/</link>
-                        </links>
-                    </configuration>
                 </plugin>
 
                 <!-- XXX FIXME

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     information: "Portions copyright [year] [name of copyright owner]".
 
     Copyright (c) 2010-2015 ForgeRock AS. All rights reserved.
-    Portions Copyright 2017-2022 Wren Security.
+    Portions Copyright 2017-2025 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wrensecurity</groupId>
         <artifactId>wrensec-parent</artifactId>
-        <version>3.4.0</version>
+        <version>4.0.2</version>
     </parent>
 
     <groupId>org.wrensecurity.wrenicf</groupId>


### PR DESCRIPTION
This PR brings the following improvements:

* `wrensec-parent` has been upgraded to the latest release
* Fixed Github Action build pipeline
* Remove invalid links from `maven-javadoc-plugin`